### PR TITLE
Fix CLI test skipping under pytest >= 9.1

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ import pytest
 @pytest.mark.cli
 class TestDiscover:
     def test_help(self):
-        main = pytest.importorskip("ssdp.__main__")
+        main = pytest.importorskip("ssdp.__main__", exc_type=ImportError)
         testing = pytest.importorskip("click.testing")
         results = testing.CliRunner().invoke(main.ssdp, ["discover", "--help"])
         assert results.exit_code == 0
@@ -19,7 +19,7 @@ class TestDiscover:
         reason="skip on macOS CI",
     )
     def test_call(self):
-        main = pytest.importorskip("ssdp.__main__")
+        main = pytest.importorskip("ssdp.__main__", exc_type=ImportError)
         testing = pytest.importorskip("click.testing")
         results = testing.CliRunner().invoke(main.ssdp, ["discover", "--max-wait", "1"])
         assert results.exit_code == 0
@@ -30,7 +30,7 @@ class TestDiscover:
         reason="skip on macOS CI",
     )
     def test_call_w_search_target(self):
-        main = pytest.importorskip("ssdp.__main__")
+        main = pytest.importorskip("ssdp.__main__", exc_type=ImportError)
         testing = pytest.importorskip("click.testing")
         results = testing.CliRunner().invoke(
             main.ssdp, ["discover", "--max-wait", "1", "--search-target", "ssdp:dial"]


### PR DESCRIPTION
pytest 9.1 changed the behaviour of "importorskip" to only ignore ModuleNotFoundError
(https://docs.pytest.org/en/stable/reference/reference.html#pytest-importorskip). ImportError is no longer ignored by default , so if click isn't installed then when ssdp/__main__.py raises ImportError we fail the test rather than skipping it as intended.